### PR TITLE
Add niche AI tool directories (real estate, HR, legal, accounting, companion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
   - [N](#n)
   - [O](#o)
   - [P](#p)
+  - [R](#r)
   - [S](#s)
   - [T](#t)
   - [V](#v)
@@ -32,6 +33,8 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - **[Productivity Directory](https://productivity.directory)** - Find, Search & Review AI Productivity Tools
 
 ## A
+- [AccountingAI.tools](https://accountingai.tools) - Directory of 28+ AI-powered accounting, bookkeeping, tax prep, and invoicing tools with pricing and reviews
+- [AIGirlfriend.tools](https://aigirlfriend.tools) - Compare 28+ AI girlfriend, boyfriend, and virtual companion apps with honest reviews
 - [AIToolsHunt](https://aitoolshunt.com) - Comprehensive AI tools directory to discover the latest AI tools
 - [Altern](https://altern.ai) - Find almost anything related to AI
 - [AI Tools Submit](https://submitaitools.org/submit-your-ai-tool/) - Submit your AI tools
@@ -154,6 +157,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## H
 
+- [HRAI.tools](https://hrai.tools) - Directory of 27+ AI-powered HR tools for recruiting, onboarding, performance management, payroll, and analytics
 - [Havnai](https://havnai.com/) - The world's first AI tool directory offering 60-second video intros for each tool and one-click AI tool lists by industry name.
 - [HeyAIworld](https://heyaiworld.com/) - All-in-one platform for finding best AI tools, people to follow, best AI tools for each profession and more.
 
@@ -168,6 +172,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## L
 
+- [LegalAI.tools](https://legalai.tools) - Compare 31+ AI tools for lawyers — legal research, contract review, compliance, e-discovery, and billing
 - [LineZine AI Tool Directory](https://linezine.com/ai-tool-directory) - Curated list of AI tools for business use
 - [ListYourTool](https://www.listyourtool.com/) - Discover the best AI tools in one place
 - [Launch Vault](https://www.launchvault.dev/) - The Ultimate Product Launch Platform for Indie Hackers and Startups
@@ -196,6 +201,10 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [PoweredbyAI](https://poweredbyai.app) - AI TOOLS & PROMPTS!
 - [Productivity Tools](https://productivity.directory) - A curated productivity directory
+
+## R
+
+- [RealEstateAI.tools](https://realestateai.tools) - Compare 27+ AI tools for real estate — lead generation, CRM, virtual staging, marketing, and property management
 
 ## S
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 ## A
 - [AccountingAI.tools](https://accountingai.tools) - Directory of 28+ AI-powered accounting, bookkeeping, tax prep, and invoicing tools with pricing and reviews
 - [AIGirlfriend.tools](https://aigirlfriend.tools) - Compare 28+ AI girlfriend, boyfriend, and virtual companion apps with honest reviews
+- [AIHumanizer.tools](https://aihumanizer.tools) - Compare AI humanizer and text rewriting tools side by side with features, pricing, and reviews
 - [AIToolsHunt](https://aitoolshunt.com) - Comprehensive AI tools directory to discover the latest AI tools
 - [Altern](https://altern.ai) - Find almost anything related to AI
 - [AI Tools Submit](https://submitaitools.org/submit-your-ai-tool/) - Submit your AI tools
@@ -108,6 +109,9 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Based Tools](https://www.basedtools.ai/) - The most Based AI Directory.
 - [Best AI Tools org](https://www.best-ai-tools.org/) - Find & Learn AI Tools with AI ChatBot + free Academy
 - [Best of Web](https://www.bestofweb.site) – Startup and founder directory. Easy and fast to submit, includes a free dofollow backlink.
+- [BestAIDetector.tools](https://bestaidetector.tools) - Compare AI content detection tools with features, accuracy rates, pricing, and reviews
+- [BestOfPodcasts.com](https://bestofpodcasts.com) - Discover the best podcasts across all genres with curated rankings, reviews, and recommendations
+- [BestWriting.tools](https://bestwriting.tools) - Directory of 27+ AI writing tools with features, pricing, reviews, and alternatives
 - [Beyond AI Tools](https://www.beyondaitools.com/) - AI tools, solutions, best practices, and more — all with multilingual support, aiming to foster AI adoption across the globe.
 - [Byblos AI](https://byblosai.com/) - Find AI tools and software using an AI search
 - [BuildVoyage](https://buildvoyage.com/) - A micro-saas directory for AI projects where the journey is what matters!
@@ -181,6 +185,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [Makerlist.io](https://makerlist.io) - Directory of tools & Startups
 - [Marketing Tools List](https://marketingtoolslist.com) - a curated list of marketing tools in various categories
+- [MattressRank.info](https://mattressrank.info) - Compare and rank 28+ mattresses with AI-powered analysis and side-by-side comparisons
 - [Most Popular AI Tools](https://mostpopularaitools.com) – Curated directory of trending AI tools across writing, design, coding, marketing & productivity.
 
 


### PR DESCRIPTION
Added 5 niche AI tool directories:

- **AccountingAI.tools** — 28+ AI accounting & bookkeeping tools
- **AIGirlfriend.tools** — 28+ AI companion apps
- **HRAI.tools** — 27+ AI HR tools
- **LegalAI.tools** — 31+ AI legal tools
- **RealEstateAI.tools** — 27+ AI real estate tools

All are independent, curated directories with pricing, features, and reviews. Alphabetically placed in appropriate sections.