### PR TITLE
Add TutuoAI (agent-native marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## T
 
+- [TutuoAI](https://www.tutuoai.com/) - Agent-native marketplace for skills/tools/configs (machine-readable APIs)
+
 - [There's An AI](https://theresanai.com) - No 1 AI Aggregator
 - [theaisurf](https://theaisurf.com/) - Discover Top AI Tools in One Clean Directory
 - [THANK JOHN](https://www.thankjohn.com/) - Free tool submissions + featured


### PR DESCRIPTION
Adds TutuoAI (https://www.tutuoai.com/) to the T section.

TutuoAI is an agent-native marketplace for skills/tools/configs with machine-readable APIs.