### PR TITLE
Add See AI First — developer-focused AI stack guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Sales Tools AI](https://salestoolsai.top/) - Find AI Tools that increase your sales
 - [Stackviv](https://stackviv.ai/) - The Largest AI Directory Featuring the Best Tools Across 1000+ Curated Categories!
 - [SearchAiDirectory](https://searchaidirectory.com/) - Find the best AI tools to solve your problems.
+- [See AI First](https://seeaifirst.com) - The Opinionated AI Stack Guide — 66 curated developer tools across 13 infrastructure layers with compare mode and bilingual EN/VI support. Open source.
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation


### PR DESCRIPTION
Hi! I'd like to add [See AI First](https://seeaifirst.com) to the directory list.

**What it is:** A curated, opinionated AI stack guide for developers — not a volume-based listing. 66 tools organized across 13 infrastructure layers (protocols, frameworks, vector databases, coding agents, etc.) with compare mode and bilingual EN/VI support.

**Why it's different from existing entries:**
- Developer infrastructure focus (not general-purpose AI tools)
- Opinionated curation (each tool has reasoning for inclusion)
- Open source: https://github.com/BARONFANTHE/seeaifirst
- Bilingual (English + Vietnamese)
- Structured data: JSON-LD schema on every route for AI agent discoverability

Thanks for maintaining this list!