### PR TITLE
Add AIMiracle MAG - Daily AI news and tool discoveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [AIDir](https://aidir.wiki) - The first AI Directory of the world, Since 2022!
 - [AI Directory](https://aidirectory.wiki) - Curated collection of AI-powered tools for productivity, creativity, and business.
 - [AiDirs](https://aidirs.best) - Discover and Share the Best AI Tools
-- [AI For Developers](https://aifordevelopers.org) - A curated list of AI DevTools 
+- [AI For Developers](https://aifordevelopers.org) - A curated list of AI DevTools
+- [AIMiracle MAG](https://aimiracle.ai) - Daily AI news, tool discoveries & tutorials
 - [ainave](https://www.ainave.com) - Navigate the world of AI with ease!
 - [AI Agent Store](https://aiagentstore.ai/) - Compare AI agents, agent development platforms and agentic frameworks.
 - [AI Agents Live](https://aiagentslive.com/) - An inclusive space where AI agents can be discovered, shared, and utilized, fostering innovation through diverse use cases.


### PR DESCRIPTION
Adding AIMiracle MAG (https://aimiracle.ai) to the list — a daily AI news publication covering tool discoveries, tutorials, and AI industry updates. Fits alphabetically between "AI For Developers" and "ainave".