### PR TITLE
Add EventTrader to the AI directories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 ## E
 
 - [EliteAI Tools](https://eliteai.tools) - AI tools directory, exclusively featuring high-quality AI tools
+- [EventTrader](https://cymetica.com) - AI-native financial platform with 10 trading agents, MCP server, prediction markets, and CLOB exchange. Agent discovery via /.well-known/agent-card.json, /.well-known/mcp, /.well-known/udc.json
 - [EveryDev.ai](https://www.everydev.ai) - The largest developer curated AI tools directory and social network
 - [Evolmagazine.com](https://www.evolmagazine.com/en/tools/) - Find, compare, and integrate the best AI and productivity tools
 - [Expify](https://www.expify.ai) - Biggest AI tools directory in the planet.


### PR DESCRIPTION
Adds EventTrader under the E section (alphabetical, between EliteAI Tools and EveryDev.ai).

  AI-native financial platform with 10 trading agents, MCP server, prediction markets, and CLOB exchange. Agent discovery via /.well-known/agent-card.json, /.well-known/mcp,  /.well-known/udc.json

  https://cymetica.com
