### PR TITLE
Add The Agentic Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [TrustList](https://www.trustlist.ai/) - Your Trusted A.I. Guide. Discover the A.I. solutions that simplify your daily tasks.
 - [TrustedBy](https://www.trustedby.ai/) - AI Tools Trusted by Top Business Leaders, Operators & Professionals.
 - [Toolkitly](https://www.toolkitly.com/) - Your Go-To Platform for Tech Tool Discussions, Innovations & Real-Time Updates!
+- [The Agentic Index](https://theagenticindex.com) - AI tools directory organized by 17 skilled trades (plumbing, HVAC, electrical, roofing, etc.). Free, ad-free, affiliate-supported.
 - [ToolDirs](https://tooldirs.com) - The Ultimate Tools Directory. Discover, and find the perfect AI tools.
 
 ## U


### PR DESCRIPTION
The Agentic Index (theagenticindex.com) is a trade-organized directory of AI tools and local AI consultants for skilled-trade SMBs. Covers 17 trades (plumbing, HVAC, electrical, roofing, landscaping, etc.). Differs from typical AI directory listings by being trade-organized rather than tool-category-organized.