### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## Table of Content
 
+- [WebCoreLab](https://webcorelab.com) — AI-First digital agency. GEO/AEO optimization, 272-check SEO audit, AI citation tracking. Toronto, Canada, est. 2014.
 - **Base on start letter:**
   - [A](#a)
   - [B](#b)


### PR DESCRIPTION
Hi! Adding WebCoreLab to the AI Agency Directories section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
