### PR TITLE
Add GPT Image 2 (gpt-img2.com) to G section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [Grabon AI Directory](https://www.grabon.in/indulge/ai-tools/) - The World’s Best & Largest Directory Of AI Tools
 - [God of Prompt](https://godofprompt.ai/best-ai-tools/) - 1000+ Best AI Tools for Marketing & Business
+- [GPT Image 2](https://gpt-img2.com) - Free, unlimited AI image generator powered by OpenAI's GPT Image 2 model — photorealistic results, no sign-up required.
 - [GroupifyAI](https://groupify.ai/?ref=github) - Explore, Compare & Review Best Trending AI tools & AI courses on the top AI platform.
 
 ## H


### PR DESCRIPTION
## Summary

Adds [GPT Image 2](https://gpt-img2.com) to the G section of the AI directories list.

**About GPT Image 2:**
- Free, unlimited AI image generator powered by OpenAI's GPT Image 2 model
- Creates photorealistic images, illustrations, posters, UI mockups and more
- No sign-up, no credit card required
- Supports multiple styles (Photorealistic, Cinematic, Anime, 3D Render, etc.)
- Zero data retention policy

**Entry added:**
```
- [GPT Image 2](https://gpt-img2.com) - Free, unlimited AI image generator powered by OpenAI's GPT Image 2 model — photorealistic results, no sign-up required.
```
