### PR TITLE
Add GPT Image 2 (gpt-img2.com) to G section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [Grabon AI Directory](https://www.grabon.in/indulge/ai-tools/) - The World’s Best & Largest Directory Of AI Tools
 - [God of Prompt](https://godofprompt.ai/best-ai-tools/) - 1000+ Best AI Tools for Marketing & Business
+- [GPT Image 2](https://gpt-img2.com) - Free, unlimited GPT Image 2 generator — turn any idea into a photorealistic picture in seconds, no sign-up required.
 - [GroupifyAI](https://groupify.ai/?ref=github) - Explore, Compare & Review Best Trending AI tools & AI courses on the top AI platform.
 
 ## H


### PR DESCRIPTION
## Add GPT Image 2

- **Site**: GPT Image 2
- **URL**: https://gpt-img2.com
- **Description**: Free, unlimited GPT Image 2 generator — turn any idea into a photorealistic picture in seconds, no sign-up required.

GPT Image 2 is a free, browser-based AI image generator powered by OpenAI's GPT Image 2 model. No sign-up, no credit card, unlimited generations with support for multiple styles and aspect ratios.