### PR TITLE
Add BestAIFor.com to AI directories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you want **a more complete list** and also **done-for-you submission** to hun
 Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://productivity.directory)*
 
 
-## Table of Content
+## Table of Contenth
 
 - **Base on start letter:**
   - [A](#a)
@@ -111,6 +111,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Based Tools](https://www.basedtools.ai/) - The most Based AI Directory.
 - [Best AI Tools org](https://www.best-ai-tools.org/) - Find & Learn AI Tools with AI ChatBot + free Academy
 - [Best of Web](https://www.bestofweb.site) – Startup and founder directory. Easy and fast to submit, includes a free dofollow backlink.
+- [BestAIFor.com](https://bestaifor.com) - Curated directory of the best AI tools and apps.
 - [Beyond AI Tools](https://www.beyondaitools.com/) - AI tools, solutions, best practices, and more — all with multilingual support, aiming to foster AI adoption across the globe.
 - [Byblos AI](https://byblosai.com/) - Find AI tools and software using an AI search
 - [BuildVoyage](https://buildvoyage.com/) - A micro-saas directory for AI projects where the journey is what matters!


### PR DESCRIPTION
BestAIFor.com is a curated directory of the best AI tools and apps. Added to the B section in alphabetical order.