### PR TITLE
Add The Agentic Index to T section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [.Tech AI TOOLS ](https://allaitools.tech) - No 1 AI Tools and Agents directory, spam-free, AI-Powered recommendations, Worthy Newsletter
 - [ToolFinder](https://toolfinder.wiki) - Discover & browse thousands of tools
 - [Toolify.ai](https://www.toolify.ai/) - Best AI Companies and Tools, Auto Updated Daily By ChatGPT
-- - [The Agentic Index](https://theagenticindex.com) - Directory of AI tools and local AI consultants for small business owners across 28 verticals — 17 trades (plumbing, HVAC, electrical, roofing, landscaping), 6 regulated pros (attorneys, doctors, financial advisors, accountants, insurance, real estate), and 5 main-street (restaurants, retail, salons, fitness, cafes). Open data feed at /tools.json (CC-BY-4.0).
+- [The Agentic AI Index](https://theagenticaiindex.com) - Directory of AI tools and local AI consultants for small business owners across 28 verticals — 17 trades (plumbing, HVAC, electrical, roofing, landscaping), 6 regulated pros (attorneys, doctors, financial advisors, accountants, insurance, real estate), and 5 main-street (restaurants, retail, salons, fitness, cafes). Open data feed at https://theagenticaiindex.com/tools.json (CC-BY-4.0).
 - [Toolwave.io](https://www.toolwave.io) - Toolwave - Discover Thousands of AI Tools for Every Use Case
 - [TopAI.tools](https://topai.tools/) - Discover the best AI tools Everyday
 - [ToolPasta by Robopost](https://toolpasta.com/) - Discover The Best AI Websites & Tools

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [.Tech AI TOOLS ](https://allaitools.tech) - No 1 AI Tools and Agents directory, spam-free, AI-Powered recommendations, Worthy Newsletter
 - [ToolFinder](https://toolfinder.wiki) - Discover & browse thousands of tools
 - [Toolify.ai](https://www.toolify.ai/) - Best AI Companies and Tools, Auto Updated Daily By ChatGPT
+- - [The Agentic Index](https://theagenticindex.com) - Directory of AI tools and local AI consultants for small business owners across 28 verticals — 17 trades (plumbing, HVAC, electrical, roofing, landscaping), 6 regulated pros (attorneys, doctors, financial advisors, accountants, insurance, real estate), and 5 main-street (restaurants, retail, salons, fitness, cafes). Open data feed at /tools.json (CC-BY-4.0).
 - [Toolwave.io](https://www.toolwave.io) - Toolwave - Discover Thousands of AI Tools for Every Use Case
 - [TopAI.tools](https://topai.tools/) - Discover the best AI tools Everyday
 - [ToolPasta by Robopost](https://toolpasta.com/) - Discover The Best AI Websites & Tools


### PR DESCRIPTION
Adding The Agentic Index — an independent directory of AI tools and local AI consultants for small business owners across 28 verticals (skilled trades, licensed professionals, and main-street businesses).

What it covers:
- 17 trades: plumbing, HVAC, electrical, roofing, construction, painting, landscaping, carpentry, appliance repair, auto service, marine, swimming pools, solar, pest control, decks/outdoor, welding, handyman
- 6 regulated pros: attorneys, doctors, real estate agents, financial advisors, accountants, insurance agents
- 5 main-street: restaurants, retail, salons, fitness, cafes

Each vertical has tool comparison tables, pricing, and a local-consultant intake. Open data feed at https://theagenticindex.com/tools.json (CC-BY-4.0).

Added to section T.

Disclosure: I run the site (Agentic Digital LLC, St. Petersburg FL).