### PR TITLE
Add AI What's On directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,5 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 Feel Free to add your AI Directory To this list
 
+
+* [AI What's On](https://aiwhatson.com/) - Curated, ad-free directory of AI conferences, summits, hackathons, expos & online talks worldwide


### PR DESCRIPTION
Adds AI What's On (https://aiwhatson.com/) — a curated, ad-free directory of AI conferences, summits, hackathons, expos and online talks worldwide. Listed under the Add Yours section.