### PR TITLE
Add ZPlatform.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
   - [V](#v)
   - [W](#w)
   - [Y](#y)
+  - [Z](#z)
 
 
 ## Featured Directories
@@ -256,6 +257,10 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 ## Y
 
 - [Yet Another AI Tool Directory](https://yaatd.com/) - Yet Another AI Tool Directory
+
+## Z
+
+- [ZPlatform.ai](https://zplatform.ai) - Directory of AI tools and software deals, each tested hands-on with a Buy, Wait, or Skip verdict.
 
 # Add Yours
 


### PR DESCRIPTION
Adds **ZPlatform.ai** under a new `## Z` section (and a `Z` entry in the Table of Contents).

ZPlatform.ai is a directory of AI tools and software deals, where each entry is tested hands-on and given a Buy / Wait / Skip verdict, organized by category. It fits the theme of this list as an AI tool/deal directory.

- Placed alphabetically (new `Z` section after `Y`)
- Added `[Z](#z)` to the Table of Content
- Follows the existing `- [Name](url) - description` format