### PR TITLE
Add SoFarBot to S section

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,4 +262,3 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 Feel Free to add your AI Directory To this list
 
-Page_UpPage_UpPage_Up

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation
+- [SoFarBot](https://www.sofarbot.com) - Curated AI tools directory with FAQs and pros & cons, plus AI news and open-source AI projects
 
 ## T
 
@@ -261,3 +262,4 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 Feel Free to add your AI Directory To this list
 
+Page_UpPage_UpPage_Up


### PR DESCRIPTION
Adds SoFarBot (https://www.sofarbot.com) to the S section — a free curated AI tools directory where every listing includes an objective description, FAQ and honest pros & cons; it also covers AI news and 80+ open-source AI projects. Free to browse, no signup, available in English and Chinese.

Entry follows the existing format and is placed at the end of the S section.

Disclosure: I'm the maintainer of SoFarBot.