### PR TITLE
Update link for 'There's An AI' aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## T
 
-- [There's An AI](https://theresanai.com) - No 1 AI Aggregator
+- [There's An AI for that](https://theresanaiforthat.com/) - No 1 AI Aggregator
 - [theaisurf](https://theaisurf.com/) - Discover Top AI Tools in One Clean Directory
 - [THANK JOHN](https://www.thankjohn.com/) - Free tool submissions + featured
 - [.Tech AI TOOLS ](https://allaitools.tech) - No 1 AI Tools and Agents directory, spam-free, AI-Powered recommendations, Worthy Newsletter


### PR DESCRIPTION
The correct, official website address is [theresanaiforthat.com](https://theresanaiforthat.com/). If you try to visit thereisanai.com, it will not work because that specific variation is either inactive or unregistered.