### PR TITLE
Add SkillsIndex (directory of AI dev tools) to section S

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [SearchAiDirectory](https://searchaidirectory.com/) - Find the best AI tools to solve your problems.
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
+- [SkillsIndex](https://skillsindex.dev) - Directory of 11,600+ AI dev tools (MCP servers, Claude skills, GPT actions, IDE plugins), each scored for security and quality.
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation
 
 ## T


### PR DESCRIPTION
Adding SkillsIndex (https://skillsindex.dev) under section S, alphabetically between "Show Me Best AI" and "Submit AI Tools".

It's a directory of 11,600+ AI developer tools: MCP servers, Claude skills, GPT actions, and IDE plugins, each scored for security and quality. Fits the same niche as the existing AI For Developers and ClaudePro.directory entries.

Single line added, follows the existing `- [Name](URL) - Description` format. Thanks for maintaining this list.