### PR TITLE
Add The Promptists

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 ## T
 
 - [There's An AI](https://theresanai.com) - No 1 AI Aggregator
+- [The Promptists](https://thepromptists.com/) - Marketplace and directory of vetted AI prompt engineers and AI artists for hire
 - [theaisurf](https://theaisurf.com/) - Discover Top AI Tools in One Clean Directory
 - [THANK JOHN](https://www.thankjohn.com/) - Free tool submissions + featured
 - [.Tech AI TOOLS ](https://allaitools.tech) - No 1 AI Tools and Agents directory, spam-free, AI-Powered recommendations, Worthy Newsletter


### PR DESCRIPTION
Adding The Promptists (thepromptists.com) — a curated marketplace and talent directory of 3,000+ vetted AI prompt engineers and artists. Added to the T section, matching existing formatting.