### PR TITLE
Add Use AI For — AI tools directory by profession

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
   - [P](#p)
   - [S](#s)
   - [T](#t)
+  - [U](#u)
   - [V](#v)
   - [W](#w)
   - [Y](#y)
@@ -243,6 +244,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## U
 - [Uno Directory](https://uno.directory) - Curated directory of tools of all categories.
+- [Use AI For](https://use-ai-for.com) - AI tools directory organized by profession
 
 ## V
 


### PR DESCRIPTION
Adds [Use AI For](https://use-ai-for.com) to the U section alphabetically after Uno Directory, and adds U to the table of contents.

**Use AI For** is a free AI tools directory organized by profession — it groups tools by job role (accountants, lawyers, plumbers, etc.) rather than by feature category, making it easier for non-technical professionals to find relevant AI tools.

Disclosure: I represent the site.