### PR TITLE
Add PulseGate (live AI-software index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [PoweredbyAI](https://poweredbyai.app) - AI TOOLS & PROMPTS!
 - [Productivity Tools](https://productivity.directory) - A curated productivity directory
+- [PulseGate](https://www.pulsegate.ai) - Live index of AI-era software (~175k apps, models, agents and infra) with no editorial gate, indexed as they ship
 
 ## S
 


### PR DESCRIPTION
Adds PulseGate to ## P.

Disclosure: I'm from the PulseGate team (Dymaxio s.r.o., Prague).

PulseGate (pulsegate.ai) is a live index of AI-era software — apps, models, agents and infrastructure — currently ~175,000 tracked, indexed as they ship rather than on a curation cycle. No editorial gate, no ranking, no pay-to-play. Free public stats JSON (/api/stats/public), RSS feeds, and an embeddable widget; methodology and a copy-paste citation at pulsegate.ai/press.

Fits ## P as a live, no-gatekeeper discovery resource alongside PoweredbyAI and Productivity Tools.