### PR TITLE
Add dailyaitools

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## D
 
+- [dailyaitools](https://dailyaitools.ai) - A new AI tool every weekday, tracked as facts: pricing, free plans, features, and side-by-side comparisons. No ratings, no reviews.
 - [DataLook.io](https://datalook.io/) - Discover the best AI tools, data science resources, and the latest insights in artificial intelligence.
 - [Dynamite AI](https://www.dynamite-ai.com/) - Yet another (FREE) AI Tools Directory.
 - [Dessign](https://dessign.net/) - AI Tools Directory.


### PR DESCRIPTION
Adds dailyaitools.ai to the D section. It is a daily-updated AI tool directory: one tool published every weekday with pricing, free-plan status, capability tags, and side-by-side comparison pages. Entries are written from the vendor's own pages and re-checked against them on a schedule, not written from model recall. No ratings or reviews.