### PR TITLE
Add dibi8 to D section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Dynamite AI](https://www.dynamite-ai.com/) - Yet another (FREE) AI Tools Directory.
 - [Dessign](https://dessign.net/) - AI Tools Directory.
 - [Desifounder](https://desifounder.com/spotlight) - Discover AI Projects & Tools.
+- [dibi8](https://dibi8.com) - Free, daily-updated directory of open-source AI dev tools — LLM frameworks, MCP servers, coding agents, dev utilities. 4 languages (en/zh/kr/vi).
 - [Direct2App](https://www.direct2app.com/) - Find the best SaaS & AI for your business.
 - [Dofollow.Tools](https://dofollow.tools) - Submit on Dofollow.Tools and get dofollow backlinks
 - [Deeplaunch.io](https://deeplaunch.io/)) - The Ultimate Directory for Online Tools and Resources


### PR DESCRIPTION
dibi8.com is a free, daily-updated directory of open-source AI/dev tools (LLM frameworks, MCP servers, coding agents, dev utilities), published in 4 languages. Adding alphabetically under D per CONTRIBUTING.md.