### PR TITLE
Add StackIndex AI to S section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation
+- [StackIndex AI](https://stackindexai.com) - The catalog of AI tools solo founders actually use, with head-to-head buying guides written from real testing.
 
 ## T
 


### PR DESCRIPTION
Adding StackIndex AI (stackindexai.com), a comparison directory for AI/SaaS tools aimed at solo founders, with editorial buying guides per category.