### PR TITLE
Add Mydentify to the AI directory list

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Makerlist.io](https://makerlist.io) - Directory of tools & Startups
 - [Marketing Tools List](https://marketingtoolslist.com) - a curated list of marketing tools in various categories
 - [Most Popular AI Tools](https://mostpopularaitools.com) – Curated directory of trending AI tools across writing, design, coding, marketing & productivity.
+- [Mydentify](https://mydentify.com/directories) - A hand-reviewed directory of product directories with filters for audience, pricing, link type, and Domain Rating.
 
 
 ## N
@@ -260,4 +261,3 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 # Add Yours
 
 Feel Free to add your AI Directory To this list
-


### PR DESCRIPTION
Adds Mydentify under M in alphabetical order.

Mydentify publishes a hand-reviewed directory of product directories with filters for audience, pricing, link type, and Domain Rating.

- Public page: https://mydentify.com/directories
- No payment, badge, vote, or reciprocal-link requirement
- One README-only line; no existing Mydentify entry was present
